### PR TITLE
Add CV page at /cv/ without header nav link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -40,6 +40,9 @@ minima:
       url: "https://github.com/yonigottesman"
   show_excerpts: true
 
+header_pages:
+  - "about copy.markdown"
+
 google_analytics:  G-H0P18BF8T9
 # Build settings
 

--- a/cv.markdown
+++ b/cv.markdown
@@ -1,0 +1,67 @@
+---
+layout: page
+title: CV
+permalink: /cv/
+---
+
+# Yoni Gottesman
+
+0544-946565 · yonigo10@gmail.com
+
+Technical AI/ML leader responsible for the strategy and technical work behind GenAI at Viz.ai. Experienced across machine learning, large-scale engineering, and distributed systems.
+
+-----
+
+## Experience
+
+### Viz.ai — 2022 – Present
+
+Bootstrapped NLP and GenAI at Viz.ai, taking the first prototypes to production systems used in clinical products.
+
+**AI Manager — Head of GenAI/NLP** *(2025 – Present)*
+Lead the team that builds and maintains Viz.ai’s NLP and GenAI capabilities, including retrieval systems and agent-based medical guidance products. Responsible for technical strategy and roadmap.
+
+**Principal AI Developer** *(2022 – 2025)*
+Technical lead across deep learning initiatives. Mentored team members and ran knowledge sharing sessions. Worked from research to production — trained and deployed deep learning and classical ML models across 1D ECG signals, NLP, and 2D/3D CT imaging.
+
+-----
+
+### Yahoo Research — Sr. Research Engineer *(2016 – 2022)*
+
+- **Yahoo Mail e-commerce text classification** — Built a PyTorch-based classifier that labels e-commerce emails by product category; took it from prototype to production and integrated it into downstream pipelines including ad ranking and user modeling.
+- **Yahoo Mail Extractions** — Designed an ML pipeline extracting structured data from raw emails; modeling in TensorFlow, data processing and collection in Spark.
+- **Omid** — A transactional layer over HBase. Implemented low-latency optimizations and integrated Omid into Apache Phoenix (became an Apache committer). Work published at **VLDB**.
+
+-----
+
+### IBM Research — Cloud Storage Group, Intern *(2015)*
+
+Researched storage class memories (SCM). Implemented a Redis clone using SCM to keep data persistent across failures. Presented at **SYSTOR**.
+
+-----
+
+### EZchip — Part-Time Software Developer *(2011 – 2014)*
+
+Developed the EZchip network processor emulator in C/C++ on Linux. Learned the EZchip processor architecture in depth.
+
+-----
+
+## Education
+
+**MSc, Electrical Engineering — Technion** *(2013 – 2016)*
+Researched a novel storage device accessible directly by virtual machines. Implemented it on FPGA along with the full software stack — Linux drivers and QEMU/KVM code. Published at **MICRO 2016**.
+
+**BSc, Computer Engineering — Technion** *(2009 – 2013)*
+Graduated *Cum Laude*, GPA 89.
+
+-----
+
+## Teaching
+
+Technion teaching assistant: *Operating Systems*, *Microprocessor Architectures*.
+
+-----
+
+## Military Service
+
+IDF — Sayeret Givati, Platoon Commander (2004 – 2008). Currently a Major in the IDF reserves.


### PR DESCRIPTION
Adds cv.markdown at permalink /cv/. Sets header_pages in _config.yml
to the existing about page only, so the new CV isn't auto-linked in
the Minima nav until explicitly added later.

https://claude.ai/code/session_01PYZ8ty24pCKteFzuJXdupC