### PR TITLE
Remove CV and name headings from CV page

### DIFF
--- a/cv.markdown
+++ b/cv.markdown
@@ -1,10 +1,7 @@
 ---
 layout: page
-title: CV
 permalink: /cv/
 ---
-
-# Yoni Gottesman
 
 0544-946565 · yonigo10@gmail.com
 


### PR DESCRIPTION
## Summary
- Drop the `title: CV` front matter so Minima doesn't render a "CV" heading
- Remove the `# Yoni Gottesman` H1 so the page opens straight into contact info

## Test plan
- [ ] Visit `/cv/` and confirm no "CV" or "Yoni Gottesman" heading appears above the contact line
- [ ] Confirm the page is still reachable only by direct URL (not linked from nav/home)

https://claude.ai/code/session_01PYZ8ty24pCKteFzuJXdupC