### PR TITLE
Avoid repeating "revenue-generating product" in CV

### DIFF
--- a/cv.markdown
+++ b/cv.markdown
@@ -12,7 +12,7 @@ Head of GenAI. Machine learning expert with a strong engineering background. Suc
 
 ### Viz.ai — 2022 – Present
 
-Led a personal side project into a revenue-generating product that sparked [Viz.ai](https://www.viz.ai)’s strategic pivot to GenAI for physicians. Had a direct hand in defining the GenAI strategy, product, and direction, and led the technical execution and development.
+Led a personal side project from scratch into a commercial product that sparked [Viz.ai](https://www.viz.ai)’s strategic pivot to GenAI for physicians. Had a direct hand in defining the GenAI strategy, product, and direction, and led the technical execution and development.
 
 **AI Manager — Head of GenAI/NLP** *(2025 – Present)*
 Lead the team that builds and maintains Viz.ai’s NLP and GenAI capabilities, including retrieval systems and agent-based medical guidance products. Responsible for technical strategy and roadmap.


### PR DESCRIPTION
## Summary
- Reword the Viz.ai role description to avoid repeating "revenue-generating product" (already used in the intro)
- "Led a personal side project into a revenue-generating product..." → "Led a personal side project from scratch into a commercial product..."

## Test plan
- [ ] Visually inspect `/cv/` page to confirm the intro and Viz.ai section read naturally without the repetition

https://claude.ai/code/session_01V9urAPKwMDFwQov5fyLBE1